### PR TITLE
Add non-potable water sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ You can customize which types of potable water points you want to add using the 
 
 ### Available POI types
 
-| POI Type        | Description                                                            |
-|:----------------|:-----------------------------------------------------------------------|
-| `drinking_water` | Public drinking water fountains (default).                            |
-| `water_point`    | Water refill stations for caravans, RVs, or marinas (only potable ones). |
-| `water_tap`      | Taps providing potable water.                                          |
-| `spring`         | Natural springs with potable water.                                   |
-| `fountain`       | Public decorative fountains explicitly marked as potable.             |
+| POI Type          | Description                                                              |
+| :---------------- | :----------------------------------------------------------------------- |
+| `drinking_water`  | Public drinking water fountains (default).                               |
+| `water_point`     | Water refill stations for caravans, RVs, or marinas (only potable ones). |
+| `water_tap`       | Taps providing potable water.                                            |
+| `spring`          | Natural springs with potable water.                                      |
+| `fountain`        | Public decorative fountains explicitly marked as potable.                |
+| `watering_places` | Watering places indented for animals explicitly marked as potable.       |
+| `non-potable`     | All water sources that are not explicitly marked as potable.             |
 
 ### Example usage
 

--- a/thirsty/core.py
+++ b/thirsty/core.py
@@ -21,6 +21,13 @@ AMENITIES = {
     "spring": ["[natural=spring][drinking_water=yes]"],
     "fountain": ["[amenity=fountain][drinking_water=yes]"],
     "watering_place": ["[amenity=watering_place][drinking_water=yes]"],
+    "non-potable": [
+        "[amenity=watering_place][drinking_water !~ yes]",
+        "[amenity=water_point][drinking_water !~ yes]",
+        "[man_made=water_tap][drinking_water !~ yes]",
+        "[natural=spring][drinking_water !~ yes]",
+        "[amenity=fountain][drinking_water !~ yes]"
+    ]
 }
 
 
@@ -55,6 +62,8 @@ def display_gpx_on_map(data, pois):
 
     # Plot POIs on the map
     for poi in pois:
+        # Determine potability of the water to set the marker color
+        potable = poi.get("tags", {}).get("drinking_water", "no") == "yes"
         
         # For the popup text, we use the amenity type if available, otherwise natural spring or water tap
         amenity = poi.get("tags", {}).get("amenity", False)
@@ -63,7 +72,7 @@ def display_gpx_on_map(data, pois):
         folium.Marker(
             location=[poi['lat'], poi['lon']],
             popup=folium.Popup(f"{popup_text}", max_width=300),
-            icon=folium.Icon(color= "blue", icon="water", prefix="fa")
+            icon=folium.Icon(color= potable and "blue" or "orange", icon="water", prefix="fa")
         ).add_to(folium_map)
 
     return folium_map

--- a/thirsty/core.py
+++ b/thirsty/core.py
@@ -64,7 +64,7 @@ def display_gpx_on_map(data, pois):
     for poi in pois:
         # Determine potability of the water to set the marker color
         potable = poi.get("tags", {}).get("drinking_water", "no") == "yes"
-        
+
         # For the popup text, we use the amenity type if available, otherwise natural spring or water tap
         amenity = poi.get("tags", {}).get("amenity", False)
         popup_text = amenity.replace("_", " ").capitalize() if amenity else ( "Natural spring" if poi.get("tags", {}).get("natural", False) else "") or ( "Water tap" if poi.get("tags", {}).get("man_made", False) else "")


### PR DESCRIPTION
## Motivation
Hikers often carry water filters, especially on longer routes where potable water sources may be sparse. In such cases, access to non-potable water sources becomes valuable. Therefore, it could be very useful to include these non-potable water sources in the generated GPX.

## Added features
- add non-potable water sources of all types
- new location marker icon
- location marker color differentiation between potable (blue) and non-potable (orange) water sources
- add watering_places as potential water source (intended for animals, but some are explicitly marked as drinkable)